### PR TITLE
Replace Notion leaderboard integration with hardcoded records

### DIFF
--- a/src/common/Turn.js
+++ b/src/common/Turn.js
@@ -8,17 +8,6 @@ const C = require('./constants.js')
 const { log, timeToString } = require('./utils.js')
 // const Mixpanel = require('mixpanel')
 
-const RACE_RESULTS_DATABASE_ID = '9fd03df83faf4347b8289223fb46e6bd'
-const LAP_RESULTS_DATABASE_ID = 'd8e17e9c905c4d19acfffbb33d6c7258'
-
-let notion
-if (process.env.IS_SERVER) {
-  const dotenv = require('dotenv')
-  dotenv.config()
-  const NotionClient = require('@notionhq/client').Client
-  notion = new NotionClient({ auth: process.env.NOTION_API_KEY })
-  console.log('set up notion client')
-}
 
 function resetBody (body) {
   delete body._listeners
@@ -355,57 +344,6 @@ class Turn {
 
           // complete laptime if it applies
           if (ship.lap > ship.currentLaptime) {
-            if (isServer && ship.currentLaptime > 0 && !ship.isABot()) {
-              notion.pages.create({
-                parent: {
-                  database_id: LAP_RESULTS_DATABASE_ID
-                },
-                properties: {
-                  Name: {
-                    title: [
-                      {
-                        text: {
-                          content: `${ship.username} finished a lap`
-                        }
-                      }
-                    ]
-                  },
-                  'Username': {
-                    rich_text: [
-                      {
-                        type: 'text',
-                        text: {
-                          content: ship.username
-                        }
-                      }
-                    ]
-                  },
-                  'Track name': {
-                    rich_text: [
-                      {
-                        type: 'text',
-                        text: {
-                          content: map.name
-                        }
-                      }
-                    ]
-                  },
-                  'Lap time': {
-                    number: ship.laptimes[ship.currentLaptime]
-                  },
-                  'Version': {
-                    rich_text: [
-                      {
-                        type: 'text',
-                        text: {
-                          content: 'v1.1 – Drafting'
-                        }
-                      }
-                    ]
-                  }
-                }
-              })
-            }
             ship.currentLaptime = ship.lap
             laptimes.push(0)
           }
@@ -421,68 +359,6 @@ class Turn {
                 timeToString(ship.bestLap()),
                 position
               )
-              if (isServer) {
-                notion.pages.create({
-                  parent: {
-                    database_id: RACE_RESULTS_DATABASE_ID
-                  },
-                  properties: {
-                    Name: {
-                      title: [
-                        {
-                          text: {
-                            content: `${ship.username} finished a race`
-                          }
-                        }
-                      ]
-                    },
-                    'Username': {
-                      rich_text: [
-                        {
-                          type: 'text',
-                          text: {
-                            content: ship.username
-                          }
-                        }
-                      ]
-                    },
-                    'Track name': {
-                      rich_text: [
-                        {
-                          type: 'text',
-                          text: {
-                            content: map.name
-                          }
-                        }
-                      ]
-                    },
-                    'Total time': {
-                      number: ship.totalTime()
-                    },
-                    'Final position': {
-                      number: position
-                    },
-                    'Number of players': {
-                      number: this.ships.filter(s => s).length
-                    },
-                    'Number of human players': {
-                      number: this.ships.filter(s => s && !s.isABot()).length
-                    },
-                    'Number of laps': {
-                      number: ship.lap
-                    }
-                  }
-                })
-                /*
-                Mixpanel.singleton.track('Player finished race', {
-                  username: ship.username,
-                  track: map.id,
-                  totalTime: ship.totalTime(),
-                  bestLap: ship.bestLap(),
-                  position: position
-                })
-                */
-              }
             }
 
             if (state === C.GAME_STATE.IN_PROGRESS) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -10,8 +10,6 @@ const utils = require('../common/utils.js')
 const Mixpanel = require('mixpanel')
 const dotenv = require('dotenv')
 dotenv.config()
-const NotionClient = require('@notionhq/client').Client
-const notion = new NotionClient({ auth: process.env.NOTION_API_KEY })
 Mixpanel.singleton = Mixpanel.init('e8281c4dfc67e5a7954bcb73f5633584', {debug: true})
 Mixpanel.singleton.track('Server woke up')
 
@@ -513,85 +511,57 @@ io.on('connection', function (socket) {
   }, 500)
 })
 
-const LAP_RESULTS_DATABASE_ID = 'd8e17e9c905c4d19acfffbb33d6c7258'
-
 const emojiForPosition = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣']
 
-function renderUsernameAndBestLap (record) {
-  if (record == null) {
-    return '–'
-  } else {
-    return `${record.username}, ${utils.timeToString(record.bestLap)}`
-  }
+const HARDCODED_BEST_LAPS = {
+  'Bowser Castle v0.1': [
+    { username: 'dasilvacontin', bestLap: 21400 },
+    { username: 'jimbo_bingus', bestLap: 22166 },
+    { username: 'CxruptExo', bestLap: 22266 },
+    { username: 'silliest goober', bestLap: 24433 }
+  ],
+  'Chicane': [
+    { username: '<b>Among</b>', bestLap: 4033 },
+    { username: 'C4spanier', bestLap: 4049 },
+    { username: 'TATE', bestLap: 4049 },
+    { username: 'silenced', bestLap: 4099 },
+    { username: 'GMANDAWGS', bestLap: 4149 }
+  ],
+  'Hairpin': [
+    { username: 'Dincan', bestLap: 9383 },
+    { username: 'C4spanier', bestLap: 9466 },
+    { username: 'Bingus', bestLap: 9533 },
+    { username: 'Shrek卐', bestLap: 9550 }
+  ],
+  'Miracle Park': [
+    { username: 'Just in', bestLap: 8266 },
+    { username: 'C4spanier', bestLap: 9283 },
+    { username: 'dasilvacontin', bestLap: 9400 },
+    { username: 'Dincan', bestLap: 9983 },
+    { username: 'silenced', bestLap: 10033 }
+  ]
 }
 
 let lastBestLapsMessage = ''
 let lastCrownOwner
-async function calculateBestTimes () {
-  let crono = Date.now()
-  let lapResults
-  let startCursor
-  const bestLaps = {
-    'Chicane': {},
-    'Hairpin': {},
-    'Miracle Park': {},
-    'Bowser Castle v0.1': {}
-  }
 
-  while (!lapResults || lapResults.has_more) {
-    lapResults = await notion.databases.query({
-      database_id: LAP_RESULTS_DATABASE_ID,
-      sorts: [
-        {
-          property: 'Lap time',
-          direction: 'ascending'
-        }
-      ],
-      filter: {
-        property: 'Invalid',
-        checkbox: {
-          equals: false
-        }
-      },
-      start_cursor: startCursor
-    })
-    lapResults.results.forEach(lap => {
-      const username = lap.properties.Username.rich_text[0].plain_text
-      const trackName = lap.properties['Track name'].rich_text[0].plain_text
-      const lapTime = lap.properties['Lap time'].number
-      if (!bestLaps[trackName]) return
-      const bestLapTimeSoFar = bestLaps[trackName][username] || Infinity
-      if (lapTime < bestLapTimeSoFar) bestLaps[trackName][username] = lapTime
-    })
-    startCursor = lapResults.next_cursor
-  }
-
-  for (let trackName in bestLaps) {
-    const bestLapsForRacers = bestLaps[trackName]
-    const bestLapsForTrack = []
-    for (let username in bestLapsForRacers) {
-      bestLapsForTrack.push({ username: username, bestLap: bestLapsForRacers[username] })
-    }
-    bestLapsForTrack.sort((r1, r2) => r1.bestLap - r2.bestLap)
-    bestLaps[trackName] = bestLapsForTrack
-  }
-
+function initBestTimes () {
   let bestLapsMessage = ''
-  for (let trackName in bestLaps) {
-    const bestLapsForTrack = bestLaps[trackName]
+  for (let trackName in HARDCODED_BEST_LAPS) {
+    const bestLapsForTrack = HARDCODED_BEST_LAPS[trackName]
     bestLapsMessage += `== Best lap in ${trackName} ==
-    🥇 ${renderUsernameAndBestLap(bestLapsForTrack[0])}
-    🥈 ${renderUsernameAndBestLap(bestLapsForTrack[1])}
-    🥉 ${renderUsernameAndBestLap(bestLapsForTrack[2])}
-    4️⃣ ${renderUsernameAndBestLap(bestLapsForTrack[3])}
-    5️⃣ ${renderUsernameAndBestLap(bestLapsForTrack[4])}
+    🥇 ${bestLapsForTrack[0] ? bestLapsForTrack[0].username + ', ' + utils.timeToString(bestLapsForTrack[0].bestLap) : '–'}
+    🥈 ${bestLapsForTrack[1] ? bestLapsForTrack[1].username + ', ' + utils.timeToString(bestLapsForTrack[1].bestLap) : '–'}
+    🥉 ${bestLapsForTrack[2] ? bestLapsForTrack[2].username + ', ' + utils.timeToString(bestLapsForTrack[2].bestLap) : '–'}
+    4️⃣ ${bestLapsForTrack[3] ? bestLapsForTrack[3].username + ', ' + utils.timeToString(bestLapsForTrack[3].bestLap) : '–'}
+    5️⃣ ${bestLapsForTrack[4] ? bestLapsForTrack[4].username + ', ' + utils.timeToString(bestLapsForTrack[4].bestLap) : '–'}
 
     `
   }
   lastBestLapsMessage = bestLapsMessage
 
+  const bestLapsForCurrentTrack = HARDCODED_BEST_LAPS[track.name] || []
   let bestLapsForCurrentTrackMessage = `== Best lap in ${track.name} ==\n`
-  const bestLapsForCurrentTrack = bestLaps[track.name]
   for (let position = 0; position < 9; position++) {
     const record = bestLapsForCurrentTrack[position]
     bestLapsForCurrentTrackMessage += `${emojiForPosition[position]} ${record ? (record.username + ', ' + utils.timeToString(record.bestLap)) : '-'}\n`
@@ -600,11 +570,8 @@ async function calculateBestTimes () {
 
   lastCrownOwner = bestLapsForCurrentTrack.length > 0 ? bestLapsForCurrentTrack[0].username : ''
   io.emit('the-crown', lastCrownOwner)
-
-  setTimeout(calculateBestTimes, 30 * 1000)
-  console.log(`calculateBestTimes took ${Date.now() - crono}`)
 }
-calculateBestTimes()
+initBestTimes()
 
 const PORT = process.env.PORT || 3000
 http.listen(PORT, function () {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -217,8 +217,8 @@ function x2 (matrix) {
 }
 
 const track4 = {
-  id: 'Bowser Castle v0.1',
-  name: 'Bowser Castle v0.1',
+  id: 'Bowser Castle',
+  name: 'Bowser Castle',
   background: 'images/Bowser_Castle.png',
   foreground: '',
   bgmusic: 'sounds/BowserCastle.wav',
@@ -514,31 +514,32 @@ io.on('connection', function (socket) {
 const emojiForPosition = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣']
 
 const HARDCODED_BEST_LAPS = {
-  'Bowser Castle v0.1': [
-    { username: 'dasilvacontin', bestLap: 21400 },
-    { username: 'jimbo_bingus', bestLap: 22166 },
-    { username: 'CxruptExo', bestLap: 22266 },
-    { username: 'silliest goober', bestLap: 24433 }
+  'Bowser Castle': [
+    { username: 'dasilvacontin', bestLap: 21.4 },
+    { username: 'jimbo_bingus', bestLap: 22.166 },
+    { username: 'CxruptExo', bestLap: 22.266 },
+    { username: 'silliest goober', bestLap: 24.433 }
   ],
   'Chicane': [
-    { username: '<b>Among</b>', bestLap: 4033 },
-    { username: 'C4spanier', bestLap: 4049 },
-    { username: 'TATE', bestLap: 4049 },
-    { username: 'silenced', bestLap: 4099 },
-    { username: 'GMANDAWGS', bestLap: 4149 }
+    { username: 'papi', bestLap: 3.983 },
+    { username: '<b>Among</b>', bestLap: 4.016 },
+    { username: 'TATE', bestLap: 4.033 },
+    { username: 'C4spanier', bestLap: 4.033 },
+    { username: 'silenced', bestLap: 4.083 }
   ],
   'Hairpin': [
-    { username: 'Dincan', bestLap: 9383 },
-    { username: 'C4spanier', bestLap: 9466 },
-    { username: 'Bingus', bestLap: 9533 },
-    { username: 'Shrek卐', bestLap: 9550 }
+    { username: 'Dincan', bestLap: 9.383 },
+    { username: 'C4spanier', bestLap: 9.466 },
+    { username: 'Bingus', bestLap: 9.533 },
+    { username: 'Shrek卐', bestLap: 9.55 },
+    { username: 'clayton', bestLap: 9.583 }
   ],
   'Miracle Park': [
-    { username: 'Just in', bestLap: 8266 },
-    { username: 'C4spanier', bestLap: 9283 },
-    { username: 'dasilvacontin', bestLap: 9400 },
-    { username: 'Dincan', bestLap: 9983 },
-    { username: 'silenced', bestLap: 10033 }
+    { username: 'Just in', bestLap: 8.266 },
+    { username: 'C4spanier', bestLap: 9.283 },
+    { username: 'dasilvacontin', bestLap: 9.4 },
+    { username: 'Dincan', bestLap: 9.983 },
+    { username: 'silenced', bestLap: 10.033 }
   ]
 }
 


### PR DESCRIPTION
Notion was too slow for reading/writing lap times on every race event. Removes all Notion API calls (lap writes, race writes, 30s polling reads) and replaces with a static HARDCODED_BEST_LAPS table that is rendered once at server startup.